### PR TITLE
Add build flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:latest as build
 RUN mkdir /app 
 COPY . /app/ 
 WORKDIR /app 
-RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -a -o sprawl . 
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -ldflags "-X main.configPath=" -a -o sprawl . 
 
 FROM scratch
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ go run main.go
 ```
 OR
 ```bash
+# Build a development version which assumes that it's ran inside the repo with all config files
 go build && ./sprawl
+# You can also build a binary that doesn't assume any configuration files,
+# but in this case you MUST use environment variables
+go build -ldflags "-X main.configPath=" && ./sprawl
 ```
 OR
 ```bash

--- a/config/config.go
+++ b/config/config.go
@@ -36,11 +36,13 @@ func (c *Config) ReadConfig(configPath string) {
 	// Use toml format for config files
 	c.v.SetConfigType("toml")
 
-	// Check for overriding config files
-	c.v.AddConfigPath(".")
-
-	// Check for user submitted config path
-	c.v.AddConfigPath(configPath)
+	// Allow build to disable config file directories
+	if configPath != "" {
+		// Check for overriding config files
+		c.v.AddConfigPath(".")
+		// Check for user submitted config path
+		c.v.AddConfigPath(configPath)
+	}
 
 	// Read config file
 	if err := c.v.ReadInConfig(); err != nil {

--- a/main.go
+++ b/main.go
@@ -9,12 +9,13 @@ import (
 var appConfig *config.Config
 var logger *zap.Logger
 var log *zap.SugaredLogger
+var configPath = "./config/default"
 
 func init() {
 	logger, _ = zap.NewProduction()
 	log = logger.Sugar()
 	appConfig = &config.Config{Logger: log}
-	appConfig.ReadConfig("./config/default")
+	appConfig.ReadConfig(configPath)
 }
 
 func main() {


### PR DESCRIPTION
Make it possible to build a binary without assuming any configuration file paths.
Bumped version tag to v0.0.2

Fixes #81 